### PR TITLE
Bug fixes in running Nasri2019 analysis

### DIFF
--- a/include/dagSched/evaluate.h
+++ b/include/dagSched/evaluate.h
@@ -150,7 +150,7 @@ void evaluate(const std::string& genparams_path, const std::string& output_fig_p
 
 
                     sched_res["Nasri2019"][test_idx] +=  G_LP_FTP_Nasri2019_C(task_set, m);
-                    time_res["Nas2019"].push_back(G_LP_FTP_Nasri2019_C.get_runtime());
+                    time_res["Nas2019"].push_back(get_Nasri2019_runtime());
 
                     timer.tic();
                     sched_res["He2019"][test_idx] +=  GP_FP_FTP_He2019_C(task_set, m);

--- a/include/dagSched/evaluate.h
+++ b/include/dagSched/evaluate.h
@@ -148,9 +148,9 @@ void evaluate(const std::string& genparams_path, const std::string& output_fig_p
                     sched_res["Fonseca2019"][test_idx] +=  GP_FP_FTP_Fonseca2019(task_set, m);
                     time_res["Fon2019"].push_back(timer.toc());
 
-                    timer.tic();
+
                     sched_res["Nasri2019"][test_idx] +=  G_LP_FTP_Nasri2019_C(task_set, m);
-                    time_res["Nas2019"].push_back(timer.toc());
+                    time_res["Nas2019"].push_back(G_LP_FTP_Nasri2019_C.get_runtime());
 
                     timer.tic();
                     sched_res["He2019"][test_idx] +=  GP_FP_FTP_He2019_C(task_set, m);

--- a/include/dagSched/tests.h
+++ b/include/dagSched/tests.h
@@ -85,6 +85,7 @@ bool P_LP_FTP_Casini2018_C(Taskset taskset, const int m);
 bool P_LP_FTP_Casini2018_C_withAssignment(Taskset taskset, const int m, const PartitioningCoresOrder_t c_order);
 
 bool G_LP_FTP_Nasri2019_C(Taskset taskset, const int m);
+double get_Nasri2019_runtime();
 
 #ifdef ZAHAF2019
 bool P_LP_EDF_Zahaf2019_C(const Taskset& taskset, const int m);

--- a/src/tests/Nasri2019.cpp
+++ b/src/tests/Nasri2019.cpp
@@ -8,7 +8,7 @@
 
 namespace dagSched{
 
-	double nasri2019_runtime = 0;
+double nasri2019_runtime = 0;
 
 bool test(std::istream &in,
 	std::istream &dag_in,
@@ -34,7 +34,7 @@ bool test(std::istream &in,
 	auto space = NP::Global::State_space<dtime_t>::explore(problem, opts);
 
 	// get CPU time of the analysis
-	runtime = space.get_cpu_time();
+	nasri2019_runtime = space.get_cpu_time();
 
 	// Extract the analysis results
 	// auto graph = std::ostringstream();
@@ -75,7 +75,7 @@ std::string convertTasksetToCsv(Taskset& taskset){
 							", " + std::to_string(i + index) +  //Job ID
 							", " + std::to_string(arrival_min) + //Release min
 							", " + std::to_string(arrival_max) + //Release max
-							", " + std::to_string((int) V[i]->c) + //Cost min
+							", " + std::to_string(0) + //Cost min
 							", " + std::to_string((int) V[i]->c) + //Cost max
 							", " + std::to_string((int) (arrival_min + taskset.tasks[x].getDeadline())) +
 							//absolute Deadline
@@ -150,7 +150,7 @@ bool G_LP_FTP_Nasri2019_C(Taskset taskset, const int m){
     return test(in, dag_in, aborts_in, m);
 }
 
-double get_runtime(){
+double get_Nasri2019_runtime(){
 	return nasri2019_runtime;
 }
 

--- a/src/tests/Nasri2019.cpp
+++ b/src/tests/Nasri2019.cpp
@@ -151,7 +151,8 @@ bool G_LP_FTP_Nasri2019_C(Taskset taskset, const int m){
 }
 
 double get_Nasri2019_runtime(){
-	return nasri2019_runtime;
+	// convert from seconds to microseconds
+	return nasri2019_runtime * 1000000;
 }
 
 }

--- a/src/tests/Nasri2019.cpp
+++ b/src/tests/Nasri2019.cpp
@@ -8,6 +8,8 @@
 
 namespace dagSched{
 
+	double nasri2019_runtime = 0;
+
 bool test(std::istream &in,
 	std::istream &dag_in,
 	std::istream &aborts_in, const int m){
@@ -30,6 +32,9 @@ bool test(std::istream &in,
 
 	// Actually call the analysis engine
 	auto space = NP::Global::State_space<dtime_t>::explore(problem, opts);
+
+	// get CPU time of the analysis
+	runtime = space.get_cpu_time();
 
 	// Extract the analysis results
 	// auto graph = std::ostringstream();
@@ -143,6 +148,10 @@ bool G_LP_FTP_Nasri2019_C(Taskset taskset, const int m){
     std::stringstream aborts_in;
 
     return test(in, dag_in, aborts_in, m);
+}
+
+double get_runtime(){
+	return nasri2019_runtime;
 }
 
 }


### PR DESCRIPTION
This pull request includes two bug fixes in the framework:  

1. **Job Set Handling in Schedule Abstraction Graph Analysis (Nasri2019)**  
   - The schedule abstraction graph analysis operates on a *job set*, not a *task set*. When analyzing a task set (rather than a single DAG task), it must first be unfolded into a job set before being passed to the analysis.  
   - This issue likely affected the results in **Fig. 11(a, b) and Fig. 16(a, b, e, f)** of the paper.  

2. **Correcting Runtime Reporting for Schedule Abstraction Graph Analysis**  
   - Previously, the reported runtime was based on *wall clock time*, which included the time required to unfold the task set.  
   - This has been corrected to report *CPU time*, which provides a more accurate measurement, especially when the analysis is run with the `parallel` option. The unfolding time is now excluded from the reported runtime.  